### PR TITLE
Add info about #ddev-description annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ A repository like this one is the way to get started. You can create a new repo 
 5. Update the install.yaml to give the necessary instructions for installing the add-on.
   * The fundamental line is the `project_files` directive, a list of files to be copied from this repo into the project `.ddev` directory.
   * You can optionally add files to the `global_files` directive as well, which will cause files to be placed in the global `.ddev` directory, `~/.ddev`.
-  * Finally, `pre_install_commands` and `post_install_commands` are supported. These can use the host-side environment variables documented [in ddev docs](https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided).
+  * Finally, `pre_install_actions` and `post_install_actions` are supported. These can use the host-side environment variables documented [in ddev docs](https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided).
+  * Each pre_install action should have `#ddev-description:<some description>` in it, and DDEV v1.21.4+ will output that to explain what it is doing.
 6. Update `tests/test.bats` to provide a reasonable test for the repository. You can run it manually with `bats tests` and it will be run on push and nightly as well. Please make sure to attend to test failures when they happen. Others will be depending on you. `bats` is a simple testing framework that just uses `bash`. You can install it with `brew install bats-core` or [see other techniques](https://bats-core.readthedocs.io/en/stable/installation.html). See [bats tutorial](https://bats-core.readthedocs.io/en/stable/).
 7. When everything is working, including the tests, you can push the repository to GitHub.
 8. Create a release on GitHub.
 9. Test manually with `ddev get <owner/repo>`.
-10. Update the README.md to describe the add-on, how to use it, and how to contribute. If there are any manual actions that have to be taken, please explain them. If it requires special configuration of the using project, please explain how to do those. Examples in [ddev/ddev-drupal9-solr](https://github.com/ddev/ddev-drupal9-solr), [ddev/ddev-memcached](https://github.com/ddev/ddev-memcached), and [ddev/ddev-beanstalkd](https://github.com/ddev/ddev-beanstalkd).
-11. Under "About" settings in the sidebar, add a good short description to your repo, and add "ddev-get" to the topics. It will immediately be added to the list provided by `ddev get --list --all`.
-12. When it has matured you will hopefully want to have it become an "official" maintained add-on. Open an issue in the [ddev queue](https://github.com/drud/ddev/issues) for that.
+10. You can test PRs with `ddev get https://github.com/<user>/<repo>/tarball/<branch>`
+11. Update the README.md to describe the add-on, how to use it, and how to contribute. If there are any manual actions that have to be taken, please explain them. If it requires special configuration of the using project, please explain how to do those. Examples in [drud/ddev-drupal9-solr](https://github.com/drud/ddev-drupal9-solr), [drud/ddev-memcached](github.com/drud/ddev-memcached), and [drud/ddev-beanstalkd](https://github.com/drud/ddev-beanstalkd).
+12. Add a good short description to your repo, and add the label "ddev-get". It will immediately be added to the list provided by `ddev get --list --all`.
+13. When it has matured you will hopefully want to have it become an "official" maintained add-on. Open an issue in the [ddev queue](https://github.com/drud/ddev/issues) for that.
 
 Note that more advanced techniques are discussed in [DDEV docs](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/#additional-service-configurations-and-add-ons-for-ddev).
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ A repository like this one is the way to get started. You can create a new repo 
 8. Create a release on GitHub.
 9. Test manually with `ddev get <owner/repo>`.
 10. You can test PRs with `ddev get https://github.com/<user>/<repo>/tarball/<branch>`
-11. Update the README.md to describe the add-on, how to use it, and how to contribute. If there are any manual actions that have to be taken, please explain them. If it requires special configuration of the using project, please explain how to do those. Examples in [drud/ddev-drupal9-solr](https://github.com/drud/ddev-drupal9-solr), [drud/ddev-memcached](github.com/drud/ddev-memcached), and [drud/ddev-beanstalkd](https://github.com/drud/ddev-beanstalkd).
+11. Update the README.md to describe the add-on, how to use it, and how to contribute. If there are any manual actions that have to be taken, please explain them. If it requires special configuration of the using project, please explain how to do those. Examples in [ddev/ddev-drupal9-solr](https://github.com/ddev/ddev-drupal9-solr), [ddev/ddev-memcached](github.com/ddev/ddev-memcached), and [ddev/ddev-beanstalkd](https://github.com/ddev/ddev-beanstalkd).
 12. Add a good short description to your repo, and add the label "ddev-get". It will immediately be added to the list provided by `ddev get --list --all`.
-13. When it has matured you will hopefully want to have it become an "official" maintained add-on. Open an issue in the [ddev queue](https://github.com/drud/ddev/issues) for that.
+13. When it has matured you will hopefully want to have it become an "official" maintained add-on. Open an issue in the [ddev queue](https://github.com/ddev/ddev/issues) for that.
 
 Note that more advanced techniques are discussed in [DDEV docs](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/#additional-service-configurations-and-add-ons-for-ddev).
 

--- a/install.yaml
+++ b/install.yaml
@@ -8,6 +8,7 @@ pre_install_actions:
   # Actions with #ddev-nodisplay will not show the execution of the action, but may show their output
 # - |
   # #ddev-nodisplay
+  #ddev-description:Check architecture type for incompatible arm64 type
   # if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then
     # echo "This package does not work on arm64 machines";
     # exit 1;
@@ -17,16 +18,21 @@ pre_install_actions:
 #- |
 #  # Using #ddev-nodisplay tells ddev to be quiet about this action and not show it or its output.
 #  #ddev-nodisplay
+#  #ddev-description:Remove solr volume
 #  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
 #    echo "This add-on requires DDEV v1.19.4 or higher, please upgrade." && exit 2
 #  fi
 #- 'echo "what is your platform.sh token" && read x'
 
 # This item shows templating using DDEV environment variables.
-# - touch somefile.${DDEV_PROJECT_TYPE}.${DDEV_DOCROOT}.txt
+# -
+#   #ddev-description:Touch a file to create it
+#   touch somefile.${DDEV_PROJECT_TYPE}.${DDEV_DOCROOT}.txt
+#
 
 # This item shows complex go templating possibilities based on yaml_read_files
 #- |
+#- #ddev-description:Create a config.platformsh.yaml
 #  cat <<EOF >.ddev/config.platformsh.yaml
 #  php_version: {{ trimPrefix "php:" .platformapp.type }}
 #  database:


### PR DESCRIPTION
As of DDEV v1.21.4+, it's best for add-ons that use pre_install or post_install_actions to have `#ddev-description` in each action to say what they are doing.

Add that info.