### PR TITLE
First round of drud->ddev changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![tests](https://github.com/drud/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## What is ddev-addon-template?
 
 This repository is a template for providing [DDEV](https://ddev.readthedocs.io) addons and services.
 
-In ddev v1.19+ addons can be installed from the command line using the `ddev get` command, for example, `ddev get drud/ddev-addon-template` or `ddev get drud/ddev-drupal9-solr`.
+In DDEV addons can be installed from the command line using the `ddev get` command, for example, `ddev get ddev/ddev-addon-template` or `ddev get drud/ddev-drupal9-solr`.
 
 A repository like this one is the way to get started. You can create a new repo from this one by clicking the template button in the top right corner of the page.
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -32,8 +32,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-addon-template
+  echo "# ddev get ddev/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-addon-template
   ddev restart >/dev/null
   # Do something useful here that verifies the add-on
   # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"


### PR DESCRIPTION
This changes references to drud to "ddev".

Remaining work: 
- [ ] References in the README to projects that haven't been moved yet
- [ ] `brew install drud/ddev/ddev` references have to be changed, especially if those don't work after migration.