### PR TITLE
Run tmate debugging session only if workflow_dispatch debug_enabled is true

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         limit-access-to-actor: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'}}
 
     - name: tests
       run: bats tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Debug with tmate set "debug_enabled"'
+        type: boolean
+        description: Debug with tmate
         required: false
-        default: "false"
+        default: false
 
 defaults:
   run:
@@ -72,12 +73,13 @@ jobs:
       run: | 
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
         docker pull memcached:1.6 >/dev/null
+
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'}}
+      if: github.event.inputs.debug_enabled == 'true'
 
     - name: tests
       run: bats tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
-        mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
+      run: mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
 
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
@@ -87,5 +86,3 @@ jobs:
     # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
       if: matrix.ddev_version == 'stable'
-
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,6 @@ jobs:
     - name: Download docker images
       run: | 
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull memcached:1.6 >/dev/null
 
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
Hi,
if we use the `workflow_dispatch` to launch the "tests" action, the `tmate debugging session` step runs even if we let the default `debug_enabled` input to `false`.

This PR fixes it and runs the `tmate debugging session` step only if the value of `debug_enabled` has been explicitly set to `true`.