### PR TITLE
Move health checks to a separate function in bats test file

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -11,6 +11,11 @@ setup() {
   ddev start -y >/dev/null
 }
 
+health_checks() {
+  # Do something useful here that verifies the add-on
+  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
+}
+
 teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
@@ -24,9 +29,7 @@ teardown() {
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
   ddev restart
-  # Do something here to verify functioning extra service
-  # For extra credit, use a real CMS with actual config.
-  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
+  health_checks
 }
 
 @test "install from release" {
@@ -35,6 +38,6 @@ teardown() {
   echo "# ddev get ddev/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ddev/ddev-addon-template
   ddev restart >/dev/null
-  # Do something useful here that verifies the add-on
-  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
+  health_checks
 }
+

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,6 +14,7 @@ setup() {
 health_checks() {
   # Do something useful here that verifies the add-on
   # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
+  ddev exec "curl -s https://localhost:443/"
 }
 
 teardown() {


### PR DESCRIPTION
Now, regarding to the template file, we have to write checks twice: 
- In `@test "install from directory"`
- And in `@test "install from release"` - the same lines.

Will be good to move that to a separate function, to not have two places to manage them. 

So, I've created a function `health_checks()` that contains only a single instance of checks.

And have moved it to the top, because it will be edited more frequiently, than test functions.