### PR TITLE
Remove HOMEBREW_NO_INSTALL_FROM_API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,10 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  # NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Allow `--HEAD` flag when running tests against HEAD
-  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   tests:


### PR DESCRIPTION
## The Issue

Lots of problems with homebrew git clone failing, for example https://github.com/ddev/ddev-mongo/actions/runs/5462288647/jobs/9941441600

## How This PR Solves The Issue

Try removing HOMEBREW_NO_INSTALL_FROM_API (DDEV only wanted it for the `brew install --HEAD` feature)

@Bo98 was kind enough to correspond via email to suggest this technique, which ought to work on linux/GitHub Actions

Related issues:

* https://github.com/Homebrew/homebrew-core/issues/135315
* https://github.com/Homebrew/homebrew-cask/issues/150323#issuecomment-1621758162
* https://github.com/Homebrew/brew/issues/15621#issuecomment-1620839202

/cc @tyler36 