### PR TITLE
docs: change sample name of add-on so it matches README instructions, fixes #35

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,6 @@
 # Details about the install.yaml file are at https://ddev.readthedocs.io/en/latest/users/extend/additional-services/#sections-and-features-of-ddev-get-add-on-installyaml
 
-name: your-addon
+name: addon-template
 
 # pre_install_actions - list of actions to run before installing the addon.
 # Examples would be removing an extraneous docker volume,


### PR DESCRIPTION
## The Issue

* #35

The README instructions say to replace 'addon-template' with your add-on name, but this string doesn't fit the pattern.

## How This PR Solves The Issue

Changes the placeholder so it matches the others.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

