### PR TITLE
Include dependencies example in template

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -68,6 +68,10 @@ global_files:
 # - commands
 # - homeadditions
 
+# List of add-on names that this add-on depends on
+dependencies:
+# - redis
+
 # DDEV environment variables can be interpolated into these actions
 post_install_actions:
 # - chmod +x ~/.ddev/commands/web/somecommand


### PR DESCRIPTION
## The Issue

There is an example of every section _except_ `dependencies`. If you're like me, that might cause you to miss it.

## How This PR Solves The Issue

Adds an commented-out example

## Related Issue Link(s)
https://discord.com/channels/664580571770388500/1184888354886647878
