### PR TITLE
All services should mount ddev-global-cache

### DIFF
--- a/docker-compose.addon-template.yaml
+++ b/docker-compose.addon-template.yaml
@@ -14,3 +14,4 @@ services:
 
     volumes:
     - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"


### PR DESCRIPTION
## The Issue

All services should mount ddev-global-cache. This becomes more important with 
* https://github.com/ddev/ddev/pull/5753

