### PR TITLE
Prevent concurrent workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write


### PR DESCRIPTION
## The Issue
Recently I was updating the tyler36/ddev-laravel-queue addon.

The tests generally take 5-6 minutes.
When I push a new commit, it triggers another workflow process. 

At one point, I click a couple of "Commit suggestion"s and I had 6 workflows running on the same branch!

## How This PR Solves The Issue

This PR configures "concurrency"  in the workflow. This _could_ be set on a per-job level, but I opted for the entire workflow with this PR. Feel free to change this is desired.

Concurrency is set to cancel in-progress workflows on a branch/tag before starting a new workflow on the same branch/tag.

See https://docs.github.com/en/actions/using-jobs/using-concurrency
 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

