### PR TITLE
docs: Don't show bad examples in install.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -11,8 +11,8 @@ pre_install_actions:
 # - |
   # #ddev-nodisplay
   #ddev-description:Check architecture type for incompatible arm64 type
-  # if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then
-    # echo "This package does not work on arm64 machines";
+  # if [ "$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
+    # echo "This package does not work on arm64 (Apple Silicon) machines";
     # exit 1;
   #fi
 
@@ -57,16 +57,20 @@ pre_install_actions:
 # Each file should contain #ddev-generated so it can be replaced by a later `ddev get`
 # if it hasn't been modified by the user.
 # DDEV environment variables can be interpolated into these filenames
+# If you use directories, they must be directories that are managed
+# by this add-on, or removal could remove things that are not owned by it
 project_files:
 - docker-compose.addon-template.yaml
-# - extra_files/
+# - some-directory/file1.txt
+# - some-directory/file2.txt
+# - extra_files_dir_created_by_this_template/
 # - somefile.sh
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames
 global_files:
-# - commands
-# - homeadditions
+# - commands/web/add-on-command
+# - homeadditions/some-file.txt
 
 # List of add-on names that this add-on depends on
 dependencies:


### PR DESCRIPTION
## The Issue

* A couple of add-ons have inadvertently used directories in the install.yaml, and shared directories, like `commands`. Thix can lead to `ddev get --remove` removing the whole directory. 
* Not all systems have the `arch` command, use `uname -m` in the example instead.

## How This PR Solves The Issue

Don't give the bad example.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

