### PR TITLE
feat: add `ddev_version_constraint` (available since DDEV v1.23.4), remove `#ddev-nodisplay`

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -8,9 +8,7 @@ name: addon-template
 # DDEV environment variables can be interpolated into these actions
 # pre_install_actions are executed in the context of the target project's root directory.
 pre_install_actions:
-  # Actions with #ddev-nodisplay will not show the execution of the action, but may show their output
   # - |
-  #   #ddev-nodisplay
   #   #ddev-description:Check architecture type for incompatible arm64 type
   #   if [ "$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
   #     echo "This package does not work on arm64 (Apple Silicon) machines";
@@ -19,10 +17,8 @@ pre_install_actions:
 
   # - "docker volume rm ddev-${DDEV_PROJECT}_solr 2>/dev/null || true"
 
+  # You can also check for client DDEV version with ddev_version_constraint (see below).
   # - |
-  #   # Using #ddev-nodisplay tells ddev to be quiet about this action and not show it or its output.
-  #   # You can also check for client DDEV version with ddev_version_constraint (see below).
-  #   #ddev-nodisplay
   #   #ddev-description:Checking DDEV version
   #   if ! ( ddev debug capabilities 2>/dev/null | grep corepack >/dev/null 2>&1 ) ; then
   #     echo "This add-on requires DDEV v1.23+ or higher, please upgrade." && exit 2
@@ -63,17 +59,17 @@ pre_install_actions:
 # If you use directories, they must be directories that are managed
 # by this add-on, or removal could remove things that are not owned by it
 project_files:
-- docker-compose.addon-template.yaml
-# - some-directory/file1.txt
-# - some-directory/file2.txt
-# - extra_files_dir_created_by_this_template/
-# - somefile.sh
+  - docker-compose.addon-template.yaml
+  # - some-directory/file1.txt
+  # - some-directory/file2.txt
+  # - extra_files_dir_created_by_this_template/
+  # - somefile.sh
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames
 global_files:
-# - commands/web/add-on-command
-# - homeadditions/some-file.txt
+  # - commands/web/add-on-command
+  # - homeadditions/some-file.txt
 
 # Version constraint for DDEV that will be validated against the running DDEV executable
 # and prevent add-on from being installed if it doesn't validate.
@@ -84,7 +80,7 @@ ddev_version_constraint: ''
 
 # List of add-on names that this add-on depends on
 dependencies:
-# - redis
+  # - redis
 
 # DDEV environment variables can be interpolated into these actions.
 # post_install_actions are executed in the context of the target project's .ddev directory.
@@ -99,7 +95,6 @@ post_install_actions:
 removal_actions:
   # - rm ~/.ddev/commands/web/somecommand
   # - |
-  #   #ddev-nodisplay
   #   if [ -f ${DDEV_APPROOT}/.ddev/docker-compose.addon-template_extras.yaml ]; then
   #     if grep -q '#ddev-generated' ${DDEV_APPROOT}/.ddev/docker-compose.addon-template_extras.yaml; then
   #       rm -f ${DDEV_APPROOT}/.ddev/docker-compose.addon-template_extras.yaml

--- a/install.yaml
+++ b/install.yaml
@@ -20,12 +20,13 @@ pre_install_actions:
   # - "docker volume rm ddev-${DDEV_PROJECT}_solr 2>/dev/null || true"
 
   # - |
-  # # Using #ddev-nodisplay tells ddev to be quiet about this action and not show it or its output.
-  # #ddev-nodisplay
-  # #ddev-description:Remove solr volume
-  # if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
-  #   echo "This add-on requires DDEV v1.19.4 or higher, please upgrade." && exit 2
-  # fi
+  #   # Using #ddev-nodisplay tells ddev to be quiet about this action and not show it or its output.
+  #   # You can also check for client DDEV version with ddev_version_constraint (see below).
+  #   #ddev-nodisplay
+  #   #ddev-description:Checking DDEV version
+  #   if ! ( ddev debug capabilities 2>/dev/null | grep corepack >/dev/null 2>&1 ) ; then
+  #     echo "This add-on requires DDEV v1.23+ or higher, please upgrade." && exit 2
+  #   fi
 
   # - 'echo "what is your platform.sh token" && read x'
 
@@ -74,6 +75,13 @@ global_files:
 # - commands/web/add-on-command
 # - homeadditions/some-file.txt
 
+# Version constraint for DDEV that will be validated against the running DDEV executable
+# and prevent add-on from being installed if it doesn't validate.
+# See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
+# Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
+# example: ddev_version_constraint: '>= v1.23.4'
+ddev_version_constraint: ''
+
 # List of add-on names that this add-on depends on
 dependencies:
 # - redis
@@ -81,9 +89,9 @@ dependencies:
 # DDEV environment variables can be interpolated into these actions.
 # post_install_actions are executed in the context of the target project's .ddev directory.
 post_install_actions:
-# - chmod +x ~/.ddev/commands/web/somecommand
-# - touch ${DDEV_APPROOT}/somefile.${GOOS}.${DDEV_WEBSERVER}
-# - perl -pi -e 's/oldstring/newstring/g' ${DDEV_APPROOT}/.ddev/docker-compose.addon-template.yaml
+  # - chmod +x ~/.ddev/commands/web/somecommand
+  # - touch ${DDEV_APPROOT}/somefile.${GOOS}.${DDEV_WEBSERVER}
+  # - perl -pi -e 's/oldstring/newstring/g' ${DDEV_APPROOT}/.ddev/docker-compose.addon-template.yaml
 
 # Shell actions that can be done during removal of the add-on.
 # Files listed in project_files section will be automatically removed here if they contain #ddev-generated line.


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6433
- https://github.com/ddev/ddev/issues/5969

## How This PR Solves The Issue

- Adds `ddev_version_constraint`.
- Removes `#ddev-nodisplay`.

## Manual Testing Instructions

See instructions from https://github.com/ddev/ddev/pull/6433

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

