### PR TITLE
add "release" tag to release test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -33,6 +33,7 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
@@ -41,4 +42,3 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
-


### PR DESCRIPTION
## The Issue
Out of the box, addon tests fail if there are no releases. This can trip up addon developers who are unaware of this workflow, or submit PRs that try to fix issue in the current release

## How This PR Solves The Issue

https://github.com/ddev/github-action-add-on-test/34 adds the ability to skip tests tagged with "release".

This PR adds this to the appropriate test.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

