### PR TITLE
extract debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * [What is ddev-addon-template?](#what-is-ddev-addon-template)
 * [Components of the repository](#components-of-the-repository)
 * [Getting started](#getting-started)
-* [How to debug in Github Actions](#how-to-debug-tests-github-actions)
+* [How to debug in Github Actions](./README_DEBUG.md)
 
 ## What is ddev-addon-template?
 
@@ -49,45 +49,5 @@ This repository is a quick way to get started. You can create a new repo from th
 Add-ons were covered in [DDEV Add-ons: Creating, maintaining, testing](https://www.youtube.com/watch?v=TmXqQe48iqE) (part of the [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training)).
 
 Note that more advanced techniques are discussed in [Advanced Add-On Techniques](https://ddev.com/blog/advanced-add-on-contributor-training/) and [DDEV docs](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/).
-
-## How to debug tests (Github Actions)
-
-1. You need an SSH-key registered with GitHub. You either pick the key you have already used with `github.com` or you create a dedicated new one with `ssh-keygen -t ed25519 -a 64 -f tmate_ed25519 -C "$(date +'%d-%m-%Y')"` and add it at `https://github.com/settings/keys`.
-
-2. Add the following snippet to `~/.ssh/config`:
-
-```
-Host *.tmate.io
-    User git
-    AddKeysToAgent yes
-    UseKeychain yes
-    PreferredAuthentications publickey
-    IdentitiesOnly yes
-    IdentityFile ~/.ssh/tmate_ed25519
-```
-3. Go to `https://github.com/<user>/<repo>/actions/workflows/tests.yml`.
-
-4. Click the `Run workflow` button and you will have the option to select the branch to run the workflow from and activate `tmate` by checking the `Debug with tmate` checkbox for this run.
-
-![tmate](images/gh-tmate.jpg)
-
-5. After the `workflow_dispatch` event was triggered, click the `All workflows` link in the sidebar and then click the `tests` action in progress workflow.
-
-7. Pick one of the jobs in progress in the sidebar.
-
-8. Wait until the current task list reaches the `tmate debugging session` section and the output shows something like:
-
-```
-106 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-107 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-108 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-109 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-```
-
-9. Copy and execute the first option `ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io` in the terminal and continue by pressing either <kbd>q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd>.
-
-10. Start the Bats test with `bats ./tests/test.bats`.
-
-For a more detailed documentation about `tmate` see [Debug your GitHub Actions by using tmate](https://mxschmitt.github.io/action-tmate/).
 
 **Contributed and maintained by `@CONTRIBUTOR`**

--- a/README_DEBUG.md
+++ b/README_DEBUG.md
@@ -1,0 +1,39 @@
+# How to debug tests (Github Actions)
+
+1. You need an SSH-key registered with GitHub. You either pick the key you have already used with `github.com` or you create a dedicated new one with `ssh-keygen -t ed25519 -a 64 -f tmate_ed25519 -C "$(date +'%d-%m-%Y')"` and add it at `https://github.com/settings/keys`.
+
+2. Add the following snippet to `~/.ssh/config`:
+
+```
+Host *.tmate.io
+    User git
+    AddKeysToAgent yes
+    UseKeychain yes
+    PreferredAuthentications publickey
+    IdentitiesOnly yes
+    IdentityFile ~/.ssh/tmate_ed25519
+```
+3. Go to `https://github.com/<user>/<repo>/actions/workflows/tests.yml`.
+
+4. Click the `Run workflow` button and you will have the option to select the branch to run the workflow from and activate `tmate` by checking the `Debug with tmate` checkbox for this run.
+
+![tmate](images/gh-tmate.jpg)
+
+5. After the `workflow_dispatch` event was triggered, click the `All workflows` link in the sidebar and then click the `tests` action in progress workflow.
+
+7. Pick one of the jobs in progress in the sidebar.
+
+8. Wait until the current task list reaches the `tmate debugging session` section and the output shows something like:
+
+```
+106 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
+107 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
+108 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
+109 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
+```
+
+9. Copy and execute the first option `ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io` in the terminal and continue by pressing either <kbd>q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd>.
+
+10. Start the Bats test with `bats ./tests/test.bats`.
+
+For a more detailed documentation about `tmate` see [Debug your GitHub Actions by using tmate](https://mxschmitt.github.io/action-tmate/).


### PR DESCRIPTION
## The Issue

I've started dropping this section from addons I create because adds noise to the main readme.

## How This PR Solves The Issue

Extracts information to a seperate file, `README_DEBUG.md`
Updates TOC link to `README_DEBUG.md`.

The idea here is we still want to keep the debug information present and available, but not overwhelm addon user with addon developer technical details.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

