### PR TITLE
Replace `ddev get` with `ddev add-on get`, update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This repository is a template for providing [DDEV](https://ddev.readthedocs.io) add-ons and services.
 
-In DDEV addons can be installed from the command line using the `ddev get` command, for example, `ddev get ddev/ddev-redis` or `ddev get ddev/ddev-solr`.
+In DDEV addons can be installed from the command line using the `ddev add-on get` command (or `ddev get` for versions of DDEV prior to v1.23.5), for example, `ddev add-on get ddev/ddev-redis` or `ddev add-on get ddev/ddev-solr`.
 
 This repository is a quick way to get started. You can create a new repo from this one by clicking the template button in the top right corner of the page.
 
@@ -39,11 +39,11 @@ This repository is a quick way to get started. You can create a new repo from th
 6. Update `tests/test.bats` to provide a reasonable test for your repository. Tests will run automatically on every push to the repository, and periodically each night. Please make sure to address test failures when they happen. Others will be depending on you. Bats is a testing framework that just uses Bash. To run a Bats test locally, you have to [install bats-core](https://bats-core.readthedocs.io/en/stable/installation.html) first. Then you download your add-on, and finally run `bats ./tests/test.bats` within the root of the uncompressed directory. To learn more about Bats see the [documentation](https://bats-core.readthedocs.io/en/stable/).
 7. When everything is working, including the tests, you can push the repository to GitHub.
 8. Create a [release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) on GitHub.
-9. Test manually with `ddev get <owner/repo>`.
-10. You can test PRs with `ddev get https://github.com/<user>/<repo>/tarball/<branch>`
+9. Test manually with `ddev add-on get <owner/repo>`.
+10. You can test PRs with `ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>`
 11. Update the `README.md` to describe the add-on, how to use it, and how to contribute. If there are any manual actions that have to be taken, please explain them. If it requires special configuration of the using project, please explain how to do those. Examples in [ddev/ddev-solr](https://github.com/ddev/ddev-solr), [ddev/ddev-memcached](https://github.com/ddev/ddev-memcached), and (advanced) [ddev-platformsh](https://github.com/ddev/ddev-platformsh).
 12. Update the `README.md` header in Title Case format, for example, use `# DDEV Redis`, not `# ddev-redis`.
-13. Add a good short description to your repo, and add the [topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics) "ddev-get". It will immediately be added to the list provided by `ddev get --list --all`.
+13. Add a good short description to your repo, and add the [topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics) "ddev-get". It will immediately be added to the list provided by `ddev add-on list --all`.
 14. When it has matured you will hopefully want to have it become an "official" maintained add-on. Open an issue in the [DDEV queue](https://github.com/ddev/ddev/issues) for that.
 
 Add-ons were covered in [DDEV Add-ons: Creating, maintaining, testing](https://www.youtube.com/watch?v=TmXqQe48iqE) (part of the [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training)).

--- a/install.yaml
+++ b/install.yaml
@@ -53,13 +53,16 @@ pre_install_actions:
   #   EOF
 
 # list of files and directories listed that are copied into project .ddev directory
-# Each file should contain #ddev-generated so it can be replaced by a later `ddev get`
+# Each file should contain #ddev-generated so it can be replaced by a later `ddev add-on get`
 # if it hasn't been modified by the user.
 # DDEV environment variables can be interpolated into these filenames
 # If you use directories, they must be directories that are managed
 # by this add-on, or removal could remove things that are not owned by it
 project_files:
   - docker-compose.addon-template.yaml
+  # - commands/web/add-on-command
+  # - commands/host/add-on-command-host
+  # - web-build/Dockerfile.addon-template
   # - some-directory/file1.txt
   # - some-directory/file2.txt
   # - extra_files_dir_created_by_this_template/
@@ -67,6 +70,9 @@ project_files:
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames
+# Note that if these files are used by a team, you will need to automate their installation
+# by adding `ddev add-on get` to your workflow to ensure that everyone has them.
+# Otherwise, use 'project_files' to commit them to the repository.
 global_files:
   # - commands/web/add-on-command
   # - homeadditions/some-file.txt

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -27,8 +27,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -37,8 +37,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-addon-template
+  echo "# ddev add-on get ddev/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ddev/ddev-addon-template
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
## The Issue

In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

And `install.yaml` can have better examples for `project_files`:

- https://github.com/backdrop-ops/ddev-backdrop-bee/issues/4#issuecomment-2423342456

## How This PR Solves The Issue

- Replaces `ddev get` with `ddev add-on get`.
- Adds more examples to `project_files`
- Adds a comment for `global_files`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

