### PR TITLE
refactor: use v1.24.3 constraint, update pull template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@
 
 ## Manual Testing Instructions
 
+```bash
+ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev restart
+```
+
 ## Automated Testing Overview
 
 <!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

--- a/install.yaml
+++ b/install.yaml
@@ -81,7 +81,7 @@ global_files:
 # and prevent add-on from being installed if it doesn't validate.
 # See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
 # Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
-ddev_version_constraint: '>= v1.24.2'
+ddev_version_constraint: '>= v1.24.3'
 
 # List of add-on names that this add-on depends on
 dependencies:


### PR DESCRIPTION
## The Issue

We want users to have DDEV v1.24.3+ (for Mutagen fix https://ddev.com/blog/open-source-for-the-win/#mutagen-problemreport)

Pull template can include a template for tarball install (I always forget the exact URL)

## How This PR Solves The Issue

Updates the mentioned files.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
