### PR TITLE
feat: update badges, replace maintained badge with last commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
+[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/releases/latest)
 
 # DDEV add-on template <!-- omit in toc -->
 


### PR DESCRIPTION
## The Issue

Maintained badge required manual update from time to time.

## How This PR Solves The Issue

- Makes `tests` badge show status for the main branch only.
- Uses https://shields.io/badges/git-hub-last-commit-branch instead of the `project is maintained` badge.
- Adds `release` badge.

## Manual Testing Instructions

https://github.com/ddev/ddev-addon-template/blob/20250410_stasadev_badges/README.md

![image](https://github.com/user-attachments/assets/dd2c12a4-fe26-4d62-ac23-2c344130b4bf)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
