### PR TITLE
feat: add badge for add-on registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml?query=branch%3Amain)
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-addon-template)](https://github.com/ddev/ddev-addon-template/releases/latest)


### PR DESCRIPTION
## The Issue

We should have more cross-references for https://addons.ddev.com/

## How This PR Solves The Issue

Adds a new badge.

## Manual Testing Instructions

https://github.com/ddev/ddev-addon-template/blob/20250415_stasadev_registry_badge/README.md

Light:
![image](https://github.com/user-attachments/assets/76e3b4a6-80d7-49ae-bc29-344aab2ed37e)

Dark:
![image](https://github.com/user-attachments/assets/a4bf9a13-4016-40fe-8392-f0399d290ffa)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
