### PR TITLE
feat(tests workflow): Downgrade permissions to contents:read

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:


### PR DESCRIPTION


## The Issue

actions:write permission was only required for the recently removed `gautamkrishnar/keepalive-workflow` action

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Set `contents: read`  as default permission

## Manual Testing Instructions

It can be tested on any repository that uses the `ddev/github-action-add-on-test` 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
