### PR TITLE
Preserve TESTDIR when using Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,11 @@ on:
         description: Debug with tmate
         required: false
         default: false
+      preserve_testdir:
+        type: boolean
+        description: Avoid deleting test directory
+        required: false
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,5 +42,6 @@ jobs:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          preserve_testdir: true
           addon_repository: ${{ env.GITHUB_REPOSITORY }}
           addon_ref: ${{ env.GITHUB_REF }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,6 @@ on:
         description: Debug with tmate
         required: false
         default: false
-      preserve_testdir:
-        type: boolean
-        description: Avoid deleting test directory
-        required: false
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,5 @@ jobs:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           debug_enabled: ${{ github.event.inputs.debug_enabled }}
-          preserve_testdir: true
           addon_repository: ${{ env.GITHUB_REPOSITORY }}
           addon_ref: ${{ env.GITHUB_REF }}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -55,10 +55,13 @@ health_checks() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  # Persist TESTDIR when used in Github Actions. Useful for artifacts.
-  [ -z "${GITHUB_ENV:-}" ] || echo "TESTDIR=${TESTDIR}" >> "${GITHUB_ENV}"
-  # Avoid deleting TESTDIR when specified. See https://github.com/ddev/github-action-add-on-test
-  [ -n "${DDEV_PRESERVE_TESTDIR:-}" ] || [ -z "${TESTDIR}" ] || rm -rf "${TESTDIR}"
+  # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
+  # See example at https://github.com/ddev/github-action-add-on-test
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "TESTDIR=${TESTDIR}" >> "${GITHUB_ENV}"
+  else
+    [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
+  fi
 }
 
 @test "install from directory" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -56,7 +56,7 @@ teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
-  # See example at https://github.com/ddev/github-action-add-on-test
+  # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
   if [ -n "${GITHUB_ENV:-}" ]; then
     echo "TESTDIR=${TESTDIR}" >> "${GITHUB_ENV}"
   else

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -55,7 +55,10 @@ health_checks() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  # Persist TESTDIR when used in Github Actions. Useful for artifacts.
+  [ -z "${GITHUB_ENV:-}" ] || echo "TESTDIR=${TESTDIR}" >> "${GITHUB_ENV}"
+  # Avoid deleting TESTDIR when specified. See https://github.com/ddev/github-action-add-on-test
+  [ -n "${DDEV_PRESERVE_TESTDIR:-}" ] || [ -z "${TESTDIR}" ] || rm -rf "${TESTDIR}"
 }
 
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

Allow bats runners to avoid deletion of the testdir. Helpful when uploading artifacts as per

- https://github.com/ddev/github-action-add-on-test/pull/50

## How This PR Solves The Issue

Detect GITHUB_ENV env variable and avoid deleting the test directory. This is set to true for runs in Github Actions. Locally you can set it as well for same behavior.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-addon-template/tarball/refs/pull/79
ddev restart
```