### PR TITLE
fix: store TESTDIR without suffix, for #79

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -58,7 +58,7 @@ teardown() {
   # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
   # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
   if [ -n "${GITHUB_ENV:-}" ]; then
-    echo "TESTDIR=${TESTDIR}" >> "${GITHUB_ENV}"
+    [ -e "${GITHUB_ENV:-}" ] && echo "TESTDIR=${HOME}/tmp/${PROJNAME}" >> "${GITHUB_ENV}"
   else
     [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
   fi


### PR DESCRIPTION
## The Issue

- For #79

## How This PR Solves The Issue

I noticed that when you have several tests, and store `TESTDIR` to `GITHUB_ENV`, you end up with this in GITHUB_ENV:

```
...
TESTDIR=/home/runner/tmp/test-ddev-addon-template.YVvnDD
TESTDIR=/home/runner/tmp/test-ddev-addon-template.TtvrpK
```

In result only the last TESTDIR is used for uploading artifacts.

TESTDIR is `~/tmp/${PROJNAME}.XXXXXX)`

It's better to store TESTDIR as `~/tmp/${PROJNAME}`, so people can use glob `${TESTDIR}*/path/to/files` to store all test results.

Also I added a check `[ -e "${GITHUB_ENV:-}" ]` (because we don't want to write to some random files locally when using `GITHUB_ENV=1 bats tests`

## Manual Testing Instructions


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
