### PR TITLE
feat: add check for `build:` with `image:` in `docker-compose.*.yaml` to use DDEV offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository is a quick way to get started. You can create a new repo from th
 10. When ready to share, make your add-on discoverable by adding the `ddev-get` [topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics).
 
 > [!TIP]
-> Run the update checker in your add-on to ensure it is up to date:
+> Run the `update-checker.sh` in your add-on to ensure it is up to date:
 >
 > ```bash
 > curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/main/.github/scripts/update-checker.sh | bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository is a quick way to get started. You can create a new repo from th
 10. When ready to share, make your add-on discoverable by adding the `ddev-get` [topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics).
 
 > [!TIP]
-> Run update checker in your add-on to ensure it is up-to-date:
+> Run the update checker in your add-on to ensure it is up to date:
 >
 > ```bash
 > curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/main/.github/scripts/update-checker.sh | bash


### PR DESCRIPTION
## The Issue

Some DDEV add-ons can't work [offline](https://ddev.readthedocs.io/en/stable/users/usage/offline/) because the base image for them is not pulled:

- `ddev/ddev-drupal-solr`
- `ddev/ddev-opensearch`
- `ddev/ddev-solr`
- `stasadev/ddev-frankenphp`

To reproduce:

```
$ docker image rm solr:9.6
$ ddev add-on get ddev/ddev-solr && ddev start && ddev poweroff

# go offline and run start again

$ ddev start
...
', stderr='failed to solve: solr:9.6: failed to resolve source metadata for docker.io/library/solr:9.6: failed to do request: Head "https://registry-1.docker.io/v2/library/solr/manifests/9.6": dial tcp: lookup registry-1.docker.io: Temporary failure in name resolution' 
```

But if you already have the `solr:9.6` image pulled, there will be no error.

## How This PR Solves The Issue

Adds check for `build:` + `image:`

DDEV has logic to pull images for `web` and `db` by using the `-${DDEV_SITENAME}-built` suffix:

```yaml
services:
  web:
    image: ${DDEV_WEBIMAGE}-${DDEV_SITENAME}-built
    build: ...
  db:
    image: ${DDEV_DBIMAGE}-${DDEV_SITENAME}-built
    build: ...
```

If this suffix is added to the add-on images with `build:`, it'll work in the same way, `solr:9.6` will be pulled, and `ddev start` will work offline.

## Manual Testing Instructions

Running update-checker.sh with `ddev/ddev-solr`:

```
$ curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/refs/heads/20250723_stasadev_build_image/.github/scripts/update-checker.sh | bash
ERROR: Actions needed:
- ./docker-compose.solr.yaml contains both 'build:' and 'image:', but 'image:' line should contain '-${DDEV_SITENAME}-built', example: 'image: ${ADDON_TEMPLATE_DOCKER_IMAGE:-busybox:stable}-${DDEV_SITENAME}-built', this is required to use DDEV offline
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
