### PR TITLE
chore: replace `busybox` with `ddev/ddev-utilities`, for ddev/ddev#7500

### DIFF
--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -125,9 +125,9 @@ check_docker_compose_yaml() {
     while IFS= read -r -d '' file; do
         if [[ -f "$file" && -r "$file" ]]; then
             if grep -q "build:" "$file" && ! grep -q "image:" "$file"; then
-                actions+=("$file contains 'build:', but there is no 'image:', example: 'image: \${ADDON_TEMPLATE_DOCKER_IMAGE:-busybox:stable}-\${DDEV_SITENAME}-built', this is required to use DDEV offline")
+                actions+=("$file contains 'build:', but there is no 'image:', example: 'image: \${ADDON_TEMPLATE_DOCKER_IMAGE:-ddev/ddev-utilities:latest}-\${DDEV_SITENAME}-built', this is required to use DDEV offline")
             elif grep -q "build:" "$file" && grep -q "image:" "$file" && ! grep -Eq "image:.*-\\\$\{DDEV_SITENAME\}-built" "$file"; then
-                actions+=("$file contains both 'build:' and 'image:', but 'image:' line should contain '-\${DDEV_SITENAME}-built', example: 'image: \${ADDON_TEMPLATE_DOCKER_IMAGE:-busybox:stable}-\${DDEV_SITENAME}-built', this is required to use DDEV offline")
+                actions+=("$file contains both 'build:' and 'image:', but 'image:' line should contain '-\${DDEV_SITENAME}-built', example: 'image: \${ADDON_TEMPLATE_DOCKER_IMAGE:-ddev/ddev-utilities:latest}-\${DDEV_SITENAME}-built', this is required to use DDEV offline")
             fi
         fi
     done < <(find . -name "docker-compose.*.yaml" -print0 2>/dev/null || true)

--- a/README_ADDON.md
+++ b/README_ADDON.md
@@ -30,7 +30,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 To change the Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.addon-template --addon-template-docker-image="busybox:stable"
+ddev dotenv set .ddev/.env.addon-template --addon-template-docker-image="ddev/ddev-utilities:latest"
 ddev add-on get ddev/ddev-addon-template
 ddev restart
 ```
@@ -41,7 +41,7 @@ All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
-| `ADDON_TEMPLATE_DOCKER_IMAGE` | `--addon-template-docker-image` | `busybox:stable` |
+| `ADDON_TEMPLATE_DOCKER_IMAGE` | `--addon-template-docker-image` | `ddev/ddev-utilities:latest` |
 
 ## Credits
 

--- a/docker-compose.addon-template.yaml
+++ b/docker-compose.addon-template.yaml
@@ -1,9 +1,8 @@
 #ddev-generated
-# Simple template to demonstrate addon-template
 services:
   addon-template:
     container_name: ddev-${DDEV_SITENAME}-addon-template
-    image: ${ADDON_TEMPLATE_DOCKER_IMAGE:-busybox:stable}
+    image: ${ADDON_TEMPLATE_DOCKER_IMAGE:-ddev/ddev-utilities:latest}
     command: tail -f /dev/null
     restart: "no"
     # These labels ensure this service is discoverable by DDEV.


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/7500

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

Uses `ddev/ddev-utilities:latest` here.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-addon-template/tarball/refs/pull/86/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
