### PR TITLE
fix: Exclude tests from release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude tests directory from releases/tarballs
+tests/ export-ignore

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -190,6 +190,19 @@ check_license() {
     fi
 }
 
+# Check .gitattributes
+check_gitattributes() {
+  local gitattributes=".gitattributes"
+
+  if [[ -f "$gitattributes" ]]; then
+    if ! grep -q "tests" "$gitattributes"; then
+      actions+=("$gitattributes should contain 'tests', see upstream file $UPSTREAM/$gitattributes")
+    fi
+  else
+    actions+=("$gitattributes is missing, see upstream file $UPSTREAM/$gitattributes")
+  fi
+}
+
 # Main function
 main() {
     if [[ ! -f "install.yaml" ]]; then
@@ -233,6 +246,9 @@ main() {
 
     # Check LICENSE file
     check_license
+  
+    # Check .gitattributes
+    check_gitattributes
 
     # If any actions are needed, throw an error
     if [[ ${#actions[@]} -gt 0 ]]; then


### PR DESCRIPTION
## The Issue

Releases by default container everything. But they sure don't need the tests

## How This PR Solves The Issue

* Add .gitattributes to exclude tests
* Add .gitattributes testing to the update checker.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
