### PR TITLE
fix(update-checker): check that command files are executable by default

### DIFF
--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -202,8 +202,14 @@ check_shebang() {
 check_command_executability() {
     local file
     while IFS= read -r -d '' file; do
-        actions+=("$file should be executable")
-    done < <(find commands -type f \! -executable -print0 2>/dev/null || true)
+        if [[ -f "$file" && -r "$file" ]]; then
+            if grep -q "^## Usage:" "$file" 2>/dev/null; then
+                if [[ ! -x "$file" ]]; then
+                    actions+=("$file should be executable, run 'chmod +x $file'")
+                fi
+            fi
+        fi
+    done < <(find commands -type f -print0 2>/dev/null || true)
 }
 
 # Check .github/workflows/tests.yml for required conditions

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -199,12 +199,11 @@ check_shebang() {
 }
 
 # Check that certain commands/**/* files are executable
-# Files starting with . or _ are exempt as they might be include files
 check_command_executability() {
     local file
     while IFS= read -r -d '' file; do
         actions+=("$file should be executable")
-    done < <(find commands -type f \! -executable \! -name '.*' \! -name '_*' -print0 2>/dev/null || true)
+    done < <(find commands -type f \! -executable -print0 2>/dev/null || true)
 }
 
 # Check .github/workflows/tests.yml for required conditions

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -202,12 +202,8 @@ check_shebang() {
 check_command_executability() {
     local file
     while IFS= read -r -d '' file; do
-        if [[ -f "$file" && -r "$file" ]]; then
-            if grep -q "^## Usage:" "$file" 2>/dev/null; then
-                if [[ ! -x "$file" ]]; then
-                    actions+=("$file should be executable, run 'chmod +x $file'")
-                fi
-            fi
+        if [[ ! -x "$file" ]]; then
+            actions+=("$file should be executable, run 'chmod +x \"$file\"'")
         fi
     done < <(find commands -type f -print0 2>/dev/null || true)
 }

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -11,6 +11,7 @@
 #   - Docker Compose files for offline usage support
 #   - File formatting (trailing newlines, whitespace)
 #   - Proper shebangs in command files
+#   - Command files are executable
 #
 # Usage (run from the add-on root directory):
 #   curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
@@ -197,6 +198,15 @@ check_shebang() {
     done < <(find commands -type f -print0 2>/dev/null || true)
 }
 
+# Check that certain commands/**/* files are executable
+# Files starting with . or _ are exempt as they might be include files
+check_command_executability() {
+    local file
+    while IFS= read -r -d '' file; do
+        actions+=("$file should be executable")
+    done < <(find commands -type f \! -executable \! -name '.*' \! -name '_*' -print0 2>/dev/null || true)
+}
+
 # Check .github/workflows/tests.yml for required conditions
 check_tests_workflow() {
     local tests_yml=".github/workflows/tests.yml"
@@ -278,7 +288,7 @@ check_addon_template_mentions() {
 # Check LICENSE file for Apache License
 check_license() {
     local license_file="LICENSE"
-    
+
     if [[ -f "$license_file" ]]; then
         if ! grep -q "Apache License" "$license_file"; then
             actions+=("LICENSE should contain 'Apache License', see upstream file $UPSTREAM/$license_file")
@@ -367,6 +377,9 @@ main() {
 
     # Check shebang in commands/**/* files
     check_shebang
+
+    # Check commands/**/* files are executable
+    check_command_executability
 
     # Check tests workflow
     check_tests_workflow


### PR DESCRIPTION
## The Issue

- Follow up from https://github.com/ddev/ddev-solr/issues/74

Command files should be executable by default

## How This PR Solves The Issue

Checks that command files are executable by default.

## Manual Testing Instructions

Inside a DDEV addon:
```bash
# Create simple non-executable command files
mkdir commands/host/
touch commands/host/{.,_}include-scripts commands/host/non-executable-command

curl -fsSL https://raw.githubusercontent.com/codebymikey/ddev-addon-template/refs/heads/20250327_codebymikey_executable_commands/.github/scripts/update-checker.sh | bash
```

## Automated Testing Overview

N/A

## Release/Deployment Notes

N/A