### PR TITLE
feat: Add a .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,12 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml}]
-indent_size = 2
-
-[{compose,docker-compose}.{yml,yaml}]
-indent_size = 4
-
-# Script files
-[*.sh]
+[*.{bats,sh,yml,yaml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[{compose,docker-compose}.{yml,yaml}]
+indent_size = 4
+
+# Script files
+[*.sh]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 tests/ export-ignore
 .github/ export-ignore
 .gitattributes export-ignore
+.editorconfig export-ignore

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -347,6 +347,19 @@ check_file_formatting() {
     done < <(git ls-files -z 2>/dev/null | grep -zv '^tests/testdata/')
 }
 
+# Check .editorconfig
+check_editorconfig() {
+  local editorconfig=".editorconfig"
+
+  if [[ -f "$editorconfig" ]]; then
+    if ! grep -q "charset = utf-8" "$editorconfig"; then
+      actions+=("$editorconfig should contain 'charset = utf-8', see upstream file $UPSTREAM/$editorconfig")
+    fi
+  else
+    actions+=("$editorconfig is missing, see upstream file $UPSTREAM/$editorconfig")
+  fi
+}
+
 # Main function
 main() {
     if [[ ! -f "install.yaml" ]]; then
@@ -399,6 +412,9 @@ main() {
 
     # Check file formatting
     check_file_formatting
+
+    # Check .editorconfig
+    check_editorconfig
 
     # Display info messages if any
     if [[ ${#info_messages[@]} -gt 0 ]]; then


### PR DESCRIPTION
## The Issue

(I didn't create an issue for this)

I was working on a shell script for for another addon request, and noticed that my editor's defaults didn't match ddev conventions. I went looking for a .editorconfig and didn't find one in the repo I was working on, so I tried adding one.

[In a review](https://github.com/ddev/ddev-elasticsearch/pull/33#pullrequestreview-4206042328), @stasadev asked me to update the template (i.e.: this repo) with an editorconfig; and update the UpdateChecker, and update the .gitattributes.


## How This PR Solves The Issue

Adds an editorconfig. Adds a simple test for it in UpdateChecker. Adds the .editorconfig to the export-ignore list.


## Manual Testing Instructions

1. Clone this branch
2. Create a new `.sh` file in the project using [an editor that supports the EditorConfig standard](https://editorconfig.org/#pre-installed) with default configuration
3. Press the `tab` key:
    - **Expected behavior**: your cursor is indented 2 spaces
    - **Previous behavior**:  your cursor is indented by something else (for me it was 4 spaces; but depending on the editor, it could be 8 spaces or 1 tab)


## Automated Testing Overview

I updated the UpdateChecker test to look for the `charset = utf-8` line, since that's probably a thing that should be in all ddev add-ons. 


## Release/Deployment Notes

None.
