### PR TITLE
chore: update constraint in first time setup, check for .editorconfig in .gitattributes

### DIFF
--- a/.github/scripts/first-time-setup.sh
+++ b/.github/scripts/first-time-setup.sh
@@ -51,7 +51,7 @@ name: $LOWERCASE_NAME
 project_files:
   - docker-compose.$LOWERCASE_NAME.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
 EOF
 }
 

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -307,6 +307,9 @@ check_gitattributes() {
     if ! grep -q "tests" "$gitattributes"; then
       actions+=("$gitattributes should contain 'tests', see upstream file $UPSTREAM/$gitattributes")
     fi
+    if ! grep -q ".editorconfig" "$gitattributes"; then
+      actions+=("$gitattributes should contain '.editorconfig', see upstream file $UPSTREAM/$gitattributes")
+    fi
   else
     actions+=("$gitattributes is missing, see upstream file $UPSTREAM/$gitattributes")
   fi


### PR DESCRIPTION
## The Issue

- Follow up for #102

## How This PR Solves The Issue

Updates the DDEV version constraint.
Checks for .editorconfig in .gitattributes

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-addon-template/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
