### PR TITLE
Use full add-on name for dependencies in install.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -86,7 +86,7 @@ ddev_version_constraint: '>= v1.24.10'
 
 # List of add-on names that this add-on depends on
 dependencies:
-  # - redis
+  # - ddev/ddev-redis
 
 # DDEV environment variables can be interpolated into these actions.
 # post_install_actions are executed in the context of the target project's .ddev directory.


### PR DESCRIPTION
## The Issue

We don't support short names, the dependency cannot be resolved from that.

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-addon-template/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
