### PR TITLE
Enforce shebang format on command files

### DIFF
--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -206,7 +206,9 @@ check_shebang() {
         if [[ -f "$file" && -r "$file" ]]; then
             local first_line
             first_line=$(head -n1 "$file" 2>/dev/null || echo "")
-            if [[ "$first_line" == "#!/bin/bash" ]]; then
+            if [[ "$first_line" != "#!"* ]]; then
+                actions+=("$file should start with a shebang like '#!/usr/bin/env bash'")
+            elif [[ "$first_line" == "#!/bin/bash" ]]; then
                 actions+=("$file should use '#!/usr/bin/env bash' instead of '#!/bin/bash'")
             fi
         fi


### PR DESCRIPTION
## The Issue

- Fixes #106

Shebangs aren't properly enforced for command files.

## How This PR Solves The Issue

Checks if the first line of command is a shebang.

## Manual Testing Instructions

Inside a DDEV addon like https://github.com/FreelyGive/ddev-claude-code or equivalent:

```bash
printf '#ddev-generated\n#!/bin/bash' > commands/web/test
curl -fsSL https://raw.githubusercontent.com/codebymikey/ddev-addon-template/refs/heads/patch-1/.github/scripts/update-checker.sh | bash
```

## Automated Testing Overview

N/A

## Release/Deployment Notes

N/A
