### PR TITLE
feat(update-checker): check for `#ddev-generated` comment

### DIFF
--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -316,6 +316,62 @@ check_license() {
     fi
 }
 
+# Check that files listed in install.yaml project_files/global_files contain exactly one #ddev-generated
+check_ddev_generated() {
+    local install_yaml="install.yaml"
+
+    local line entry count in_section section dir_file
+    local list_item_re='^[[:space:]]*-[[:space:]]+(.*)'
+
+    for section in project_files global_files; do
+        in_section=false
+        while IFS= read -r line; do
+            # Detect section header
+            if [[ "$line" == "${section}:" ]]; then
+                in_section=true
+                continue
+            fi
+
+            [[ "$in_section" != "true" ]] && continue
+
+            # A top-level YAML key (starts with a letter) ends the section
+            [[ "$line" =~ ^[a-zA-Z] ]] && break
+
+            # Match non-commented list entries with any indentation: "- <value>"
+            [[ "$line" =~ $list_item_re ]] || continue
+            entry="${BASH_REMATCH[1]}"
+
+            [[ -z "$entry" ]] && continue
+
+            # Skip entries with environment variable interpolation (can't resolve at check time)
+            [[ "$entry" =~ \$\{ ]] && continue
+
+            # For directories, check all files inside recursively
+            if [[ -d "$entry" ]]; then
+                while IFS= read -r -d '' dir_file; do
+                    count=$(grep -c "#ddev-generated" "$dir_file" 2>/dev/null) || count=0
+                    if [[ "$count" -eq 0 ]]; then
+                        actions+=("$dir_file (in directory $entry listed in install.yaml $section) does not contain '#ddev-generated'")
+                    elif [[ "$count" -gt 1 ]]; then
+                        actions+=("$dir_file (in directory $entry listed in install.yaml $section) should contain exactly one '#ddev-generated', found $count occurrences")
+                    fi
+                done < <(find "$entry" -type f -print0 2>/dev/null)
+                continue
+            fi
+
+            [[ ! -f "$entry" ]] && continue
+
+            count=$(grep -c "#ddev-generated" "$entry" 2>/dev/null) || count=0
+
+            if [[ "$count" -eq 0 ]]; then
+                actions+=("$entry is listed in install.yaml ($section) but does not contain '#ddev-generated'")
+            elif [[ "$count" -gt 1 ]]; then
+                actions+=("$entry is listed in install.yaml ($section) should contain exactly one '#ddev-generated', found $count occurrences")
+            fi
+        done < "$install_yaml"
+    done
+}
+
 # Check .gitattributes
 check_gitattributes() {
   local gitattributes=".gitattributes"
@@ -414,6 +470,9 @@ run_checks() {
 
     # Check install.yaml for conditions
     check_install_yaml
+
+    # Check #ddev-generated in files listed in install.yaml
+    check_ddev_generated
 
     # Check docker-compose.*.yaml for conditions
     check_docker_compose_yaml

--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -316,11 +316,11 @@ check_license() {
     fi
 }
 
-# Check that files listed in install.yaml project_files/global_files contain exactly one #ddev-generated
+# Check that files listed in install.yaml project_files/global_files contain #ddev-generated
 check_ddev_generated() {
     local install_yaml="install.yaml"
 
-    local line entry count in_section section dir_file
+    local line entry in_section section dir_file
     local list_item_re='^[[:space:]]*-[[:space:]]+(.*)'
 
     for section in project_files global_files; do
@@ -349,11 +349,8 @@ check_ddev_generated() {
             # For directories, check all files inside recursively
             if [[ -d "$entry" ]]; then
                 while IFS= read -r -d '' dir_file; do
-                    count=$(grep -c "#ddev-generated" "$dir_file" 2>/dev/null) || count=0
-                    if [[ "$count" -eq 0 ]]; then
+                    if ! grep -q "#ddev-generated" "$dir_file" 2>/dev/null; then
                         actions+=("$dir_file (in directory $entry listed in install.yaml $section) does not contain '#ddev-generated'")
-                    elif [[ "$count" -gt 1 ]]; then
-                        actions+=("$dir_file (in directory $entry listed in install.yaml $section) should contain exactly one '#ddev-generated', found $count occurrences")
                     fi
                 done < <(find "$entry" -type f -print0 2>/dev/null)
                 continue
@@ -361,12 +358,8 @@ check_ddev_generated() {
 
             [[ ! -f "$entry" ]] && continue
 
-            count=$(grep -c "#ddev-generated" "$entry" 2>/dev/null) || count=0
-
-            if [[ "$count" -eq 0 ]]; then
+            if ! grep -q "#ddev-generated" "$entry" 2>/dev/null; then
                 actions+=("$entry is listed in install.yaml ($section) but does not contain '#ddev-generated'")
-            elif [[ "$count" -gt 1 ]]; then
-                actions+=("$entry is listed in install.yaml ($section) should contain exactly one '#ddev-generated', found $count occurrences")
             fi
         done < "$install_yaml"
     done


### PR DESCRIPTION
## The Issue

We don't check for `#ddev-generated` inside `project_files` and `global_files`.

## How This PR Solves The Issue

Adds a check for `#ddev-generated` in files installed by the add-on.

## Manual Testing Instructions

```bash
curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/refs/heads/20260604_stasadev_update_checker/.github/scripts/update-checker.sh | bash
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
