### PR TITLE
feat(update-checker): validate add-on dependencies

### DIFF
--- a/.github/scripts/update-checker.sh
+++ b/.github/scripts/update-checker.sh
@@ -365,6 +365,42 @@ check_ddev_generated() {
     done
 }
 
+# Check that dependencies in install.yaml use org/repo format
+check_dependencies() {
+    local install_yaml="install.yaml"
+
+    local line entry in_section
+    local list_item_re='^[[:space:]]*-[[:space:]]+(.*)'
+
+    in_section=false
+    while IFS= read -r line; do
+        if [[ "$line" == "dependencies:" ]]; then
+            in_section=true
+            continue
+        fi
+
+        [[ "$in_section" != "true" ]] && continue
+
+        # A top-level YAML key (starts with a letter) ends the section
+        [[ "$line" =~ ^[a-zA-Z] ]] && break
+
+        [[ "$line" =~ $list_item_re ]] || continue
+        entry="${BASH_REMATCH[1]}"
+
+        [[ -z "$entry" ]] && continue
+
+        if [[ "$entry" != */* ]]; then
+            local example_repo
+            if [[ "$entry" == ddev-* ]]; then
+                example_repo="ddev/$entry"
+            else
+                example_repo="ddev/ddev-$entry"
+            fi
+            actions+=("install.yaml dependency '$entry' should use org/repo format (e.g. '$example_repo'), see upstream file $UPSTREAM/$install_yaml")
+        fi
+    done < "$install_yaml"
+}
+
 # Check .gitattributes
 check_gitattributes() {
   local gitattributes=".gitattributes"
@@ -466,6 +502,9 @@ run_checks() {
 
     # Check #ddev-generated in files listed in install.yaml
     check_ddev_generated
+
+    # Check dependencies use org/repo format
+    check_dependencies
 
     # Check docker-compose.*.yaml for conditions
     check_docker_compose_yaml

--- a/install.yaml
+++ b/install.yaml
@@ -85,6 +85,7 @@ global_files:
 ddev_version_constraint: '>= v1.24.10'
 
 # List of add-on names that this add-on depends on
+# Dependencies must use org/repo format (e.g. ddev/ddev-redis), otherwise DDEV cannot resolve them
 dependencies:
   # - ddev/ddev-redis
 


### PR DESCRIPTION
## The Issue

We don't check for `dependencies` format inside the `install.yaml`.

## How This PR Solves The Issue

Adds a check for the full `org/repo` dependency format.

## Manual Testing Instructions

```bash
curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/refs/heads/20260604_stasadev_update_checker/.github/scripts/update-checker.sh | bash
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
